### PR TITLE
Cleaning up sphero

### DIFF
--- a/lib/artoo/drivers/sphero.rb
+++ b/lib/artoo/drivers/sphero.rb
@@ -30,9 +30,8 @@ module Artoo
         matching_response_types messages, ::Sphero::Response::SensorData
       end
 
-      def set_color(r, g=nil, b=nil)
-        r, g, b = color(r, g, b)
-        connection.rgb(r, g, b)
+      def set_color(*colors)
+        connection.rgb(*color(colors))
       end
 
       def color(*colors)


### PR DESCRIPTION
This should put it to an [A](https://codeclimate.com/github/hybridgroup/artoo/Artoo::Drivers::Sphero). Some of the private methods should probably be pushed to the `Driver` class. I also wish there was a better way to handle messages.

Tests:

``` bash
$ rake
Run options: --seed 29185

# Running tests:

....................SSS..............S.............................
```
