### PR TITLE
Fix for set_color method in Sphero driver

### DIFF
--- a/examples/sphero_cycle.rb
+++ b/examples/sphero_cycle.rb
@@ -1,0 +1,15 @@
+require 'artoo'
+
+connection :sphero, :adaptor => :sphero, :port => '127.0.0.1:4560'
+device :sphero, :driver => :sphero
+  
+work do
+	sphero.set_color(0, 0, 0)
+	sphero.set_color(:red)
+	sphero.set_color(:yellow)
+	sphero.set_color(:green)
+	sphero.set_color(0, 255, 255)
+	sphero.set_color(:blue)
+	sphero.set_color(255, 0, 255)
+	sphero.set_color(:white)
+end

--- a/lib/artoo/drivers/sphero.rb
+++ b/lib/artoo/drivers/sphero.rb
@@ -31,7 +31,7 @@ module Artoo
       end
 
       def set_color(*colors)
-        connection.rgb(*color(colors))
+        connection.rgb(*color(*colors))
       end
 
       def color(*colors)


### PR DESCRIPTION
The method call to color was causing an ArgumentError (1 for 3) in the
call to rgb. This fix now returns either the predefined array of integers
for symbols or passes the provided values through to rgb.
