### PR TITLE
Adding dependencies for tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,3 +18,7 @@ gem 'guard'
 gem 'guard-livereload'
 gem 'guard-sprockets'
 gem 'guard-compass'
+
+# For tests
+gem 'minitest'
+gem 'mocha'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ DEPENDENCIES
   hybridgroup-argus
   hybridgroup-firmata
   hybridgroup-sphero
-  minitest (~> 4.6)
-  mocha (~> 0.13)
+  minitest
+  mocha
   sass
   sprockets


### PR DESCRIPTION
When running "rake test" locally, error messages were returned because of missing bundle dependencies.

Adding mocha and minitest solves it
