### PR TITLE
API splats arguments list when sending commands to a device

### DIFF
--- a/lib/artoo/api/api.rb
+++ b/lib/artoo/api/api.rb
@@ -57,7 +57,7 @@ module Artoo
       # Execute robot command
       # @return [JSON] command
       post '/robots/:robotid/devices/:deviceid/commands/:commandid' do
-        result = device(@params['robotid'], @params['deviceid']).command(@params['commandid'], command_params)
+        result = device(@params['robotid'], @params['deviceid']).command(@params['commandid'], *command_params)
         return MultiJson.dump({'result' => result})
       end
 


### PR DESCRIPTION
Fix for issue #33 "Wrong number of arguments passed in RESTful JSON API when sending a command
Edit".
