### PR TITLE
Added information about the socat dependency

### DIFF
--- a/documentation/platforms/sphero/index.html
+++ b/documentation/platforms/sphero/index.html
@@ -86,6 +86,11 @@
                 </p>
                 <pre class="CodeRay">gem install artoo-sphero
 </pre>
+                <p>Afterwards you need to install <em>socat</em> - for this please run
+                  the following command (works on both OSX and Linux):</p>
+
+                <pre class="CodeRay">artoo install socat</pre>
+
                 <h2>How to use</h2>
                 <p>Example of a simple program that makes the Sphero roll and change colors.</p>
                 <pre class="CodeRay"> require <span class="string"><span class="delimiter">'</span><span class="content">artoo</span><span class="delimiter">'</span></span>
@@ -146,9 +151,6 @@ Scanning ...
                 <p>Now you are ready to connect to the Sphero using the socket, in this example port 8023:</p>
                 <pre class="CodeRay">artoo connect serial Sphero-WRW 8023
 </pre>
-                <p>In order for the last command to work you need to have the <em>socat</em> package installed. You can install it via:</p>
-                <pre class="CodeRay">sudo apt-get install socat</pre>
-            
               </section><section class="drivers"><h2>Drivers</h2>
                 <p>
                   There is only one driver for the Sphero.


### PR DESCRIPTION
In order for artoo or at least artoo-sphero to work the `socat` package needs to be installed on Linux based systems. This is as mentioned in hybridgroup/artoo-sphero#6 .  I don't know if it's always installed on Ubuntu - however it isn't on all Debian based systems (running Linux Mint Debian Edition) so mentioning it probably helps all Linux users.

If this is a general dependency I believe it'd be worth adding in a more common getting started place or something. This way I only added it to the sphero documentation as I know it applies here.

Cheers,
Tobi
