### PR TITLE
Robot Names

### DIFF
--- a/examples/hello.rb
+++ b/examples/hello.rb
@@ -2,11 +2,14 @@ require 'artoo'
 
 connection :loop
 
+name "Johnny"
+
 work do
   every(3.seconds) do
-    puts "hello"
+    puts "Hello. My name is #{name}."
   end
+
   after(10.seconds) do
-  	puts "wow"
+    puts "Wow."
   end
 end

--- a/lib/artoo/delegator.rb
+++ b/lib/artoo/delegator.rb
@@ -20,7 +20,7 @@ module Artoo
       end
     end
 
-    delegate :connection, :device, :work, :api, :set, :test?, :cli?
+    delegate :connection, :device, :name, :work, :api, :set, :test?, :cli?
 
     class << self
       attr_accessor :target

--- a/lib/artoo/robot.rb
+++ b/lib/artoo/robot.rb
@@ -40,7 +40,7 @@ module Artoo
     # @option params [Collection] :connections
     # @option params [Collection] :devices
     def initialize(params={})
-      @name = params[:name] || "Robot #{random_string}"
+      @name = params[:name] || current_class.name || "Robot #{random_string}"
       @commands = params[:commands] || []
       initialize_connections(params[:connections] || {})
       initialize_devices(params[:devices] || {})

--- a/lib/artoo/robot_class_methods.rb
+++ b/lib/artoo/robot_class_methods.rb
@@ -29,6 +29,11 @@ module Artoo
         @device_types << {:name => name}.merge(params)
       end
 
+      def name(new_name = false)
+        @name = new_name if new_name
+        @name
+      end
+
       # The work that needs to be performed
       # @example
       #   work do


### PR DESCRIPTION
Small code change that allows for basic robots to have names, rather than before where they had to be set when a descendent class of `Artoo::Robot` was instantiated.

Example:

``` ruby
require 'artoo'

name "Ultron"

connection :loop

work do
  after 1.second do
    puts "My name is #{name}!"
  end
end
```

:anchor: 
