### PR TITLE
Fixed a bug affecting all websocket requests to fail with a 200 error

### DIFF
--- a/lib/artoo/api/api.rb
+++ b/lib/artoo/api/api.rb
@@ -21,6 +21,10 @@ module Artoo
       def on_connection(connection)
         while request = connection.request
           dispatch!(connection, request)
+          if request.websocket?
+            connection.detach
+            return 
+          end
         end
       end
 

--- a/lib/artoo/api/route_helpers.rb
+++ b/lib/artoo/api/route_helpers.rb
@@ -140,10 +140,10 @@ module Artoo
             route!      connection, req
           end
           if resp && !resp.nil?
-            return if req.is_a?(Reel::WebSocket)
+            return if req.websocket?
             status, body = resp
             begin
-              req.respond status, body
+              req.respond status, body 
             rescue Errno::EAGAIN
               retry
             end


### PR DESCRIPTION
I _think_ that there was a bug created by changes to the reel 0.4.0 gem. It's very easy to reproduce, simply enable the api on a robot, visit the http interface, and try to receive events from a device. You'll see in the javascript console that: WebSocket connection to 'ws://localhost:8023/robots/robot-name-here/devices/device-name-here/events' failed: Unexpected response code: 200  

I'm pretty sure this is due to these changes (https://github.com/celluloid/reel/pull/73) in reel. I'm not sure if my fix is precisely the way you'd like to see this handled, but I'm pretty sure it's the easiest way to resolve this problem.
