### PR TITLE
Adds new commands to Artoo bluetooth

### DIFF
--- a/lib/artoo/commands/bluetooth.rb
+++ b/lib/artoo/commands/bluetooth.rb
@@ -27,7 +27,7 @@ module Artoo
       end
 
       desc "unbind [ADDRESS] [NAME]", "Unbinds a Bluetooth device from a serial port"
-      def bind(address, name)
+      def unbind(address, name)
         case os
         when :linux
           run("sudo rfcomm unbind #{address}")


### PR DESCRIPTION
Adds:
1. artoo bluetooth pair <bluetooth_address>
2. artoo bluetooth unpair <bluetooth_address>
3. artoo bluetooth unbind <bluetooth_address> <name>
