### PR TITLE
Fixed logo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Artoo](https://raw.github.com/hybridgroup/artoo/gh-pages/images/artoo-logo.png)](http://artoo.io)
+[![Artoo](https://cdn.rawgit.com/hybridgroup/artoo/artoo.io/source/images/elements/artoo.png)](http://artoo.io)
 
 http://artoo.io/
 


### PR DESCRIPTION
![](https://cdn.rawgit.com/hybridgroup/artoo/artoo.io/source/images/elements/artoo.png)

Similar to https://github.com/hybridgroup/gobot/pull/68, fixed the logo and cached in https://rawgit.com/
