### PR TITLE
Bump version for thor and multi_json gems

### DIFF
--- a/artoo.gemspec
+++ b/artoo.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'celluloid-io', '>= 0.16.0.pre'
   s.add_runtime_dependency 'http', '~> 0.5.0'
   s.add_runtime_dependency 'reel', '~> 0.4.0'
-  s.add_runtime_dependency 'multi_json', '~> 1.6.0'
+  s.add_runtime_dependency 'multi_json', '~> 1.10.1'
   s.add_runtime_dependency 'rake'
   s.add_runtime_dependency 'pry', '~> 0.9.0'
   s.add_runtime_dependency 'thor', '~> 0.19.1'


### PR DESCRIPTION
I'm trying to use artoo in rails (4.1.4) application and I have a problem with version conflicts.
