### PR TITLE
When closing pin, turn it off

### DIFF
--- a/lib/artoo/adaptors/io/digital_pin.rb
+++ b/lib/artoo/adaptors/io/digital_pin.rb
@@ -78,6 +78,7 @@ module Artoo
 
         # Unexports the pin in GPIO to leave it free
         def close
+          off! if @mode == 'w'
           File.open("#{ GPIO_PATH }/unexport", "w") { |f| f.write("#{pin_num}") }
         end
       end


### PR DESCRIPTION
``` ruby
work do
    led.on
end
```

Currently even after shutting down robot, LED will stay on even if GPIO have been unexported and isn't accessible anymore.

This PR fixes it so when PIN is closed it will be turned off.
