### PR TITLE
Fix link to Roomba site

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Artoo has a extensible system for connecting to hardware devices. The following 
   - [OpenCV](http://opencv.org/) <=> [Adaptor](https://github.com/hybridgroup/artoo-opencv)
   - [Pebble](http://getpebble.com/) <=> [Adaptor](https://github.com/hybridgroup/artoo-pebble)
   - [Raspberry Pi](http://www.raspberrypi.org/) <=> [Adaptor](https://github.com/hybridgroup/artoo-raspi)
-  - [Roomba](http://www.irobot.com/us/robots/Educators/Create.aspx) <=> [Adaptor](https://github.com/hybridgroup/artoo-roomba)
+  - [Roomba](http://www.irobot.com/About-iRobot/STEM.aspx) <=> [Adaptor](https://github.com/hybridgroup/artoo-roomba)
   - [Spark Core](http://www.spark.io/) <=> [Adaptor](https://github.com/hybridgroup/artoo-spark)
   - [Sphero](http://www.gosphero.com/) <=> [Adaptor](https://github.com/hybridgroup/artoo-sphero)
 


### PR DESCRIPTION
Update URL to point to current location of iRobot Create description

This p.r. points to the same page that the [artoo Roomba documentation](http://artoo.io/documentation/platforms/roomba/) links to from "+ info about the Roomba" button to be consistent (the current link results in a "page not found" error).

For reference, here is that most recent [Wayback Machine snapshot](https://web.archive.org/web/20130605070627/http://www.irobot.com/us/robots/Educators/Create.aspx) I could find of it.

Let me know if there is a different resource to point to and I'd be happy to update the commit. Cheers!
