### PR TITLE
changed celluloid[-io] gem versions to use pessimistic operator

### DIFF
--- a/artoo.gemspec
+++ b/artoo.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'celluloid', '>= 0.16.0.pre'
-  s.add_runtime_dependency 'celluloid-io', '>= 0.16.0.pre'
+  s.add_runtime_dependency 'celluloid', '~> 0.16.0'
+  s.add_runtime_dependency 'celluloid-io', '~> 0.16.0'
   s.add_runtime_dependency 'http', '~> 0.6.1'
   s.add_runtime_dependency 'reel', '~> 0.5.0'
   s.add_runtime_dependency 'multi_json', '~> 1.10.1'


### PR DESCRIPTION
better to control the major version of celluloid that's pulled in. currently the `'>= 0.16.0.pre'` specification will pull in:

```
Using celluloid-essentials 0.20.0.pre8
Using celluloid 0.17.0.pre4
Using celluloid-io 0.16.2
```

and on the 0.17.0.pre4 version of celluloid, `require celluloid/autostart` is broken:

```
[master] ~/devel/artoo bundle exec ruby -r 'celluloid/autostart' -e ''
/Users/Sophia/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require': cannot load such file -- celluloid/supervision (LoadError)
        from /Users/Sophia/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Users/Sophia/.gem/ruby/2.1.5/gems/celluloid-essentials-0.20.0.pre8/lib/celluloid/essentials.rb:23:in `<top (required)>'
        from /Users/Sophia/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Users/Sophia/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Users/Sophia/.gem/ruby/2.1.5/gems/celluloid-0.17.0.pre4/lib/celluloid.rb:470:in `<top (required)>'
        from /Users/Sophia/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Users/Sophia/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
        from /Users/Sophia/.gem/ruby/2.1.5/gems/celluloid-0.17.0.pre4/lib/celluloid/autostart.rb:1:in `<top (required)>'
        from /Users/Sophia/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `require'
        from /Users/Sophia/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:135:in `rescue in require'
        from /Users/Sophia/.rubies/ruby-2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:144:in `require'
```