### PR TITLE
Fix bug where parameters are taken into set_pin method

### DIFF
--- a/lib/artoo/adaptors/io/digital_pin.rb
+++ b/lib/artoo/adaptors/io/digital_pin.rb
@@ -56,7 +56,9 @@ module Artoo
           end
         end
 
-        def set_pin(mode:, direction:)
+        def set_pin(settings)
+          mode = settings[:mode]
+          direction = settings[:direction]
           File.open("#{ GPIO_PATH }/gpio#{ pin_num }/direction", "w") { |f| f.write(direction) }
           @pin_file = File.open("#{ GPIO_PATH }/gpio#{ pin_num }/value", mode)
         end


### PR DESCRIPTION
I just want to start and say this is an awesome micro-framework you all have built. I've been using it in a recent project of mine, and a few weeks ago encountered a bug when running my program that I wrote. The program that I wrote that caused me to investigate this bug can be found at:
https://github.com/aceburgess/entra-raspberrypi-code

I ended up fixing the bug on my local Raspberry PI a few weeks back so unfortunately I don't have any screen-shot that I can show for what the error was saying, but I saw it stems from the digital_pin.rb file and my understanding is that the set_pin method is being called on line 53 and 55 with a hash as a parameter but the set_pin method on line 59 was not taking in a hash or saving the data into the variables that are called later in that set_pin method. I forked the repo and fixed the bug here so I could share this with you in case you didn't already know.

Thanks for the awesome software though! It's been very helpful in this hardware project I've been working on for the past few weeks.